### PR TITLE
Allow masters to decide the topic destination

### DIFF
--- a/app/assets/stylesheets/modules/game/topics/_new_topic_and_category.scss
+++ b/app/assets/stylesheets/modules/game/topics/_new_topic_and_category.scss
@@ -1,5 +1,9 @@
 #topic-content-form {
-  #title, #description, #name {
+  #title,
+  #description,
+  #name,
+  #topic_group_default_topics_destination,
+  #topic_destination {
     width: 300px;
     margin-bottom: 10px;
     clear: both;
@@ -7,6 +11,12 @@
 
   #name:disabled {
     background-color: #efefef;
+  }
+
+  #topic_group_default_topics_destination,
+  #topic_destination {
+    height: 30px;
+    background-color: #fff;
   }
 
   .topic-fields label {

--- a/app/controllers/game/topic_groups_controller.rb
+++ b/app/controllers/game/topic_groups_controller.rb
@@ -82,7 +82,7 @@ class Game::TopicGroupsController < Game::BaseController
   end
 
   def topic_group_params
-    params.permit(:name)
+    params.permit(:name, :default_topics_destination)
   end
 
   def current_topic_group

--- a/app/controllers/game/topics_controller.rb
+++ b/app/controllers/game/topics_controller.rb
@@ -88,6 +88,6 @@ class Game::TopicsController < Game::BaseController
   end
 
   def topic_params
-    params.permit(:title, :description, :topic_group_id)
+    params.permit(:title, :description, :topic_group_id, :destination)
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# Public: Represents a topic
+#
+# The destination attribute decides where to redirect the user when he/she
+# enters in the topic. The possible values are:
+#
+# * 0: redirects to first page
+# * 1: redirects to last page and last post
+# * 2: behaves according to the topic group rule
 class Topic < ActiveRecord::Base
   extend FriendlyId
   friendly_id :title, :use => :slugged
@@ -16,4 +24,14 @@ class Topic < ActiveRecord::Base
   scope :by_group_id, ->(group_id) { joins(:topic_group)
     .where('topic_groups.id = ?', group_id).order('topics.position')
   }
+
+  def redirect_to_last_page?
+    destination == 1 ||
+    (destination == 2 && topic_group.default_topics_destination == 1)
+  end
+
+  def redirect_to_first_page?
+    destination == 0 ||
+    (destination == 2 && topic_group.default_topics_destination == 0)
+  end
 end

--- a/app/models/topic_group.rb
+++ b/app/models/topic_group.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# Public: Represents a group of topics
+#
+# The default_topics_destination attribute decides where to redirect the user
+# when he/she enters in a topic. The possible values are:
+#
+# * 0: redirects to first page
+# * 1: redirects to last page and last post
 class TopicGroup < ActiveRecord::Base
   TOPIC_GROUP_LIMIT = 3
 

--- a/app/views/game/topic_groups/_form.html.erb
+++ b/app/views/game/topic_groups/_form.html.erb
@@ -8,6 +8,18 @@
   <label>Nome (máximo de 20 caracteres)</label><br />
   <input type="text" name="name" maxlength="20" id="name"
     value="<%= topic_group.name %>" <%= 'disabled' if limit_reached %> />
+  <label>Por padrão, ao entrar nos tópicos deste grupo devemos ir para: </label>
+  <%=
+    select(
+      'topic_group',
+      'default_topics_destination',
+      [['A última página', 1], ['A primeira página', 0]],
+      {},
+      {
+        name: 'default_topics_destination'
+      }
+    )
+  %>
 </fieldset>
 
 <script>

--- a/app/views/game/topics/_form.html.erb
+++ b/app/views/game/topics/_form.html.erb
@@ -9,6 +9,17 @@
     <label>Descrição</label><br />
     <input type="text" name="description" id="description"
       value="<%= topic.description %>" />
+    <label>Por padrão, ao entrar nos tópicos deste grupo devemos ir para: </label>
+    <% default_destination = topic.new_record? ?  2 : topic.destination %>
+    <%=
+      select_tag 'destination',
+        options_for_select([
+          ['A página indicada pela regra do grupo', 2],
+          ['A última página', 1],
+          ['A primeira página', 0]
+        ], default_destination),
+        { id: 'topic_destination' }
+    %>
   </div>
 </fieldset>
 

--- a/app/views/game/topics/_topic_line.html.erb
+++ b/app/views/game/topics/_topic_line.html.erb
@@ -2,8 +2,14 @@
   <nav class="active fm-nav <%= 'game-master' if @identity.game_master? %>"
     data-topic-id="<%= topic.id %>">
 
+    <%
+      url = topic.redirect_to_last_page? ?
+        redirect_to_last_post_game_topic_path(game, topic) :
+        game_posts_path(game, topic)
+    %>
+
     <%=
-      link_to redirect_to_last_post_game_topic_path(game, topic),
+      link_to url,
         data: { 'fm-index' => roman_number(index) },
         class: 'animated fadeInLeft' do %>
       <span class="title"><%= topic.title %></span>

--- a/db/migrate/20160626133029_add_default_topics_destination_to_topic_groups.rb
+++ b/db/migrate/20160626133029_add_default_topics_destination_to_topic_groups.rb
@@ -1,0 +1,5 @@
+class AddDefaultTopicsDestinationToTopicGroups < ActiveRecord::Migration
+  def change
+    add_column :topic_groups, :default_topics_destination, :integer, default: 1, null: false
+  end
+end

--- a/db/migrate/20160626133250_add_destination_to_topics.rb
+++ b/db/migrate/20160626133250_add_destination_to_topics.rb
@@ -1,0 +1,5 @@
+class AddDestinationToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :destination, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160528142124) do
+ActiveRecord::Schema.define(version: 20160626133250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,12 +115,13 @@ ActiveRecord::Schema.define(version: 20160528142124) do
   add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
 
   create_table "topic_groups", force: :cascade do |t|
-    t.integer  "game_id",                            null: false
-    t.string   "name",       limit: 100,             null: false
-    t.integer  "position",               default: 0
-    t.string   "slug",                               null: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.integer  "game_id",                                            null: false
+    t.string   "name",                       limit: 100,             null: false
+    t.integer  "position",                               default: 0
+    t.string   "slug",                                               null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
+    t.integer  "default_topics_destination",             default: 1, null: false
   end
 
   add_index "topic_groups", ["game_id"], name: "index_topic_groups_on_game_id", using: :btree
@@ -136,6 +137,7 @@ ActiveRecord::Schema.define(version: 20160528142124) do
     t.string   "slug",                                   null: false
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
+    t.integer  "destination",                default: 1, null: false
   end
 
   add_index "topics", ["character_id"], name: "index_topics_on_character_id", using: :btree


### PR DESCRIPTION
The destination attribute decides where to redirect the user when he/she enters in the topic. The possible values are:

* 0: redirects to first page
* 1: redirects to last page and last post
* 2: behaves according to the topic group rule